### PR TITLE
fix(i18n): suggested clarifications for user error messages

### DIFF
--- a/src/main/resources/public/widgets/last-infos-widget/i18n/fr.json
+++ b/src/main/resources/public/widgets/last-infos-widget/i18n/fr.json
@@ -1,8 +1,8 @@
 {
     "last-infos-widget": "Actualités",
     "actualites.widget.author": "Auteur",
-    "actualites.widget.bad.request.invalid.size": "Le paramètre resultSize est invalide, il doit être compris entre 1 et 20",
-    "actualites.widget.bad.request.size.must.be.an.integer": "Le paramètre resultSize doit être un entier",
+    "actualites.widget.bad.request.invalid.size": "Nombre d'actualités invalide : veillez choisir un nombre compris entre 1 et 20.",
+    "actualites.widget.bad.request.size.must.be.an.integer": "Nombre d'actualités invalide : veillez utiliser un nombre.",
     "actualites.widget.config": "Configurer",
     "actualites.widget.config.cancel": "Annuler",
     "actualites.widget.config.nbr": "Nombre d'actualités à afficher",


### PR DESCRIPTION
Suggested a more user friendly error message in case the user or front end select an invalid number of news to show in the widget. Users should be more able to understand the wrongness while changing this value.