### PR TITLE
feat(form): EV-173 add number of articles per tab

### DIFF
--- a/src/main/resources/public/template/main.html
+++ b/src/main/resources/public/template/main.html
@@ -53,44 +53,60 @@
             </a>
         </nav>
     </div>
-    <!--<section class="margin-four">-->
+    <!-- Tabs (all, published, drafts ...) -->
     <section class="margin-four main-col">
         <div class="twelve cell">
             <container template="createInfo"></container>
         </div>
         <div class="twelve cell">
             <div class="twelve tabs vertical-spacing-twice heading-tabs">
+                <!-- All articles -->
                 <header ng-class="{selected : !hasParam('filter')}" class="horizontal-spacing-twice">
                     <a href="[['#' + $location.path()]]" class="horizontal-spacing">
-                        <span><i18n>filters.all</i18n></span>
+                        <span>
+                            <i18n>filters.all</i18n>
+                            <i class="badge" ng-if="displayedInfos.all.length != 0">[[numberOfArticlesByThread(ARTICLE_TYPES.all)]]</i>
+                        </span>
                     </a>
                 </header>
+                <!-- Published articles -->
                 <header ng-class="{selected : findParam('filter') === ACTUALITES_CONFIGURATION.infoFilter.PUBLISHED}"
                     ng-if="oneRight('contrib')" class="horizontal-spacing-twice">
                     <a href="[['#' + $location.path() + '?filter=' + ACTUALITES_CONFIGURATION.infoFilter.PUBLISHED]]"
                        class="horizontal-spacing">
-                        <span><i18n>filters.published</i18n></span>
+                        <span>
+                            <i18n>filters.published</i18n>
+                            <i class="badge" ng-if="displayedInfos.all.length != 0">[[numberOfArticlesByThread(ARTICLE_TYPES.all) - numberOfArticlesByThread(ARTICLE_TYPES.drafts)]]</i>
+                        </span>
                     </a>
                 </header>
+                <!-- Headlines -->
                 <header ng-class="{selected : findParam('filter') === ACTUALITES_CONFIGURATION.infoFilter.HEADLINE,
                            disabled : displayedInfos.headlines.length === 0 }" class="horizontal-spacing-twice">
                     <a ng-if="displayedInfos.headlines.length > 0"
                        href="[['#' + $location.path() + '?filter=' + ACTUALITES_CONFIGURATION.infoFilter.HEADLINE]]"
                        class="horizontal-spacing">
-                        <span><i18n>filters.headline</i18n></span>
+                        <span>
+                            <i18n>filters.headline</i18n>
+                            <i class="badge" ng-if="displayedInfos.all.length != 0">[[numberOfArticlesByThread(ARTICLE_TYPES.headlines)]]</i></span>
                     </a>
                     <span class="horizontal-spacing" ng-if="displayedInfos.headlines.length === 0"><i18n>filters.headline</i18n></span>
                 </header>
+                <!-- Drafts -->
                 <header ng-class="{'selected' : findParam('filter') === ACTUALITES_CONFIGURATION.infoFilter.DRAFT,
                         'disabled' : displayedInfos.drafts.length === 0}"
                     ng-if="oneRight('contrib')" class="horizontal-spacing-twice">
                     <a href="[['#' + $location.path() + '?filter=' + ACTUALITES_CONFIGURATION.infoFilter.DRAFT]]"
                        ng-if="displayedInfos.drafts.length > 0"
                        class="horizontal-spacing">
-                        <span><i18n>filters.drafts</i18n></span>
+                        <span>
+                            <i18n>filters.drafts</i18n>
+                            <i class="badge" ng-if="displayedInfos.all.length != 0">[[numberOfArticlesByThread(ARTICLE_TYPES.drafts)]]</i>
+                        </span>
                     </a>
                     <span class="horizontal-spacing" ng-if="displayedInfos.drafts.length === 0"><i18n>filters.drafts</i18n></span>
                 </header>
+                <!-- Pending -->
                 <header ng-class="{'selected' : findParam('filter') === ACTUALITES_CONFIGURATION.infoFilter.PENDING,
                             'disabled': displayedInfos.pendings.length === 0}"
                     ng-if="oneRight('submit')" class="horizontal-spacing-twice">
@@ -99,17 +115,20 @@
                        class="horizontal-spacing">
                         <span>
                             <i18n>filters.submitted.waiting</i18n>
-                            <i class="badge">[[displayedInfos.pendings.length]]</i>
+                            <i class="badge" ng-if="displayedInfos.all.length != 0">[[numberOfArticlesByThread(ARTICLE_TYPES.pendings)]]</i>
                         </span>
                     </a>
                     <span class="horizontal-spacing" ng-if="displayedInfos.pendings.length === 0"><i18n>filters.submitted.waiting</i18n></span>
                 </header>
             </div>
         </div>
+        <!-- Filter by -->
         <div class="twelve cell">
+            <!-- No articles case -->
             <div ng-if="display.emptyThread" class="row">
                 <h2><i18n>actualites.thread.empty</i18n></h2>
             </div>
+            <!-- Drafts + Pending -->
             <div ng-if="findParam('filter') === ACTUALITES_CONFIGURATION.infoFilter.DRAFT
                         || findParam('filter') === ACTUALITES_CONFIGURATION.infoFilter.PENDING
                         || !hasParam('filter')">
@@ -124,6 +143,7 @@
                     </div>
                 </div>
             </div>
+            <!-- This weeks' articles -->
             <div ng-if="findParam('filter') !== ACTUALITES_CONFIGURATION.infoFilter.DRAFT
                         && findParam('filter') !== ACTUALITES_CONFIGURATION.infoFilter.PENDING">
                 <h4 class="row">
@@ -143,7 +163,7 @@
                         <container template="infoEdit"></container>
                     </div>
                 </div>
-
+                <!-- Other articles -->
                 <div ng-if="countByStatus(displayedInfos.beforeThisWeekInfos) > 0">
                     <h4 class="row" ng-if="(displayedInfos.beforeThisWeekInfos | filter:filterByThreads(false) | limitTo:display.limit).length > 0">
                         <i18n>before.this.week</i18n>

--- a/src/main/resources/public/ts/controller.ts
+++ b/src/main/resources/public/ts/controller.ts
@@ -3,6 +3,7 @@ import { ACTUALITES_CONFIGURATION } from './configuration';
 import { safeApply } from './functions/safeApply';
 import { Info, Thread, Comment, Utils } from './model';
 import * as jQuery from 'jquery'
+import { ARTICLE_TYPES } from './core/constants/article-types.constants';
 import http from "axios";
 
 const model = typedModel as any;
@@ -30,11 +31,22 @@ export const actualiteController = ng.controller('ActualitesController',
                 $scope.ACTUALITES_CONFIGURATION = ACTUALITES_CONFIGURATION;
                 $scope.displayedInfos = null;
                 $scope.infoTimeline = null;
+                $scope.ARTICLE_TYPES = ARTICLE_TYPES;
 
                 model.infos.on('sync', function () {
                     model.infos.deselectAll();
                     safeApply($scope);
                 });
+
+                $scope.numberOfArticlesByThread = (state:string) : number => {
+                    if (!$scope.displayedInfos[state]) { //case where state does not exist in $scope.displayedInfos
+                        return 0;
+                    }
+                    //if no threads are selected ("All threads"), the length of all the articles of the tab is returned
+                    //otherwise only the ones from the selected thread
+                    return $scope.currentInfo.thread === undefined ? $scope.displayedInfos[state].length :
+                        $scope.displayedInfos[state].filter(i => i.thread_id === $scope.currentThread._id).length;
+                };
 
                 route({
                     // Routes viewThread, viewInfo adn viewComment are used by notifications

--- a/src/main/resources/public/ts/core/constants/article-types.constants.ts
+++ b/src/main/resources/public/ts/core/constants/article-types.constants.ts
@@ -1,0 +1,12 @@
+/**
+ * Contains each article type
+ * @see in model.threads.infos
+ */
+export const ARTICLE_TYPES = {
+    all: 'all',
+    thisWeek: 'thisWeekInfos',
+    beforeThisWeek: 'beforeThisWeekInfos',
+    drafts: 'drafts',
+    pendings: 'pendings',
+    headlines: 'headlines'
+}


### PR DESCRIPTION
Le nombre d'articles est affiché à côté de chaque onglet.
Il s'adapte dynamiquement si on sélectionne un fil d'actualité en particulier.
Ne s'affiche pas si aucun article n'a été publié dans aucun fil.