### PR TITLE
fix: #WB-1548, remove possibility to comment an info not shared

### DIFF
--- a/deployment/actualites/test.scala
+++ b/deployment/actualites/test.scala
@@ -19,3 +19,6 @@
   .group("Actualites Scenario - shared manage") {
     net.atos.entng.actualites.test.integration.ActualitesScenario.scnManage
   }
+  .group("Actualites Scenario - comment security") {
+    net.atos.entng.actualites.test.integration.ActualitesScenario.scnCommentSecurity
+  }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,15 @@
-gradle:
-  image: gradle:4.5-alpine
-  working_dir: /home/gradle/project
-  volumes:
-    - ./:/home/gradle/project
-    - ~/.m2:/home/gradle/.m2
-    - ~/.gradle:/home/gradle/.gradle
+services:
+  gradle:
+    image: opendigitaleducation/gradle:4.5.1
+    working_dir: /home/gradle/project
+    volumes:
+      - ./:/home/gradle/project
+      - ~/.m2:/home/gradle/.m2
+      - ~/.gradle:/home/gradle/.gradle
 
-node:
-  image: opendigitaleducation/node
-  working_dir: /home/node/app
-  volumes:
-    - ./:/home/node/app
-    - ~/.npm:/.npm
+  node:
+    image: opendigitaleducation/node:10
+    working_dir: /home/node/app
+    volumes:
+      - ./:/home/node/app
+      - ~/.npm:/.npm


### PR DESCRIPTION
## Describe your changes

Cette PR permet de renforcer les vérifications faites lors de l'ajout d'un commentaire ou lors de la modification d'un commentaire existant afin de ne pas permettre à un utilisateur de commenter une info qui ne lui a pas été partagée.

## Checklist tests

Les cas couverts par cette PR ont été ajoutés aux scérnarios de tests d'intégration.

## Issue ticket number and link

[WB-1548](https://edifice-community.atlassian.net/browse/WB-1548)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [x] If it is a consequent feature, I have added thorough tests.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to this project (must specify in **Description**)

[WB-1548]: https://edifice-community.atlassian.net/browse/WB-1548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ