### PR TITLE
feat: #WB-1402, do not delete a thread when its owner is deleted

### DIFF
--- a/src/main/java/net/atos/entng/actualites/filters/ThreadFilter.java
+++ b/src/main/java/net/atos/entng/actualites/filters/ThreadFilter.java
@@ -19,33 +19,33 @@
 
 package net.atos.entng.actualites.filters;
 
-import static org.entcore.common.sql.Sql.parseId;
-
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-
-import net.atos.entng.actualites.controllers.ThreadController;
 
 import org.entcore.common.http.filter.ResourcesProvider;
 import org.entcore.common.sql.Sql;
+import static org.entcore.common.sql.Sql.parseId;
 import org.entcore.common.sql.SqlConf;
 import org.entcore.common.sql.SqlConfs;
 import org.entcore.common.sql.SqlResult;
+import static org.entcore.common.user.DefaultFunctions.ADMIN_LOCAL;
 import org.entcore.common.user.UserInfos;
+
+import fr.wseduc.webutils.http.Binding;
 import io.vertx.core.Handler;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-
-import fr.wseduc.webutils.http.Binding;
+import net.atos.entng.actualites.controllers.ThreadController;
 
 public class ThreadFilter implements ResourcesProvider {
 
 	@Override
 	public void authorize(final HttpServerRequest request, final Binding binding, final UserInfos user, final Handler<Boolean> handler) {
 		SqlConf conf = SqlConfs.getConf(ThreadController.class.getName());
-		String id = null;
+		String id;
 		if(isThreadShare(binding)){
 			id = request.params().get("id");
 		} else {
@@ -62,6 +62,10 @@ public class ThreadFilter implements ResourcesProvider {
 			if (user.getGroupsIds() != null) {
 				groupsAndUserIds.addAll(user.getGroupsIds());
 			}
+			// Structures which the user is an ADML of.
+			final List<String> admlStructuresIds = user.isADML() 
+				? user.getFunctions().get(ADMIN_LOCAL).getScope() 
+				: Collections.EMPTY_LIST;
 			// Query
 			StringBuilder query = new StringBuilder();
 			JsonArray values = new JsonArray();
@@ -69,14 +73,22 @@ public class ThreadFilter implements ResourcesProvider {
 				.append(" FROM actualites.thread AS t")
 				.append(" LEFT JOIN actualites.thread_shares AS ts ON t.id = ts.resource_id")
 				.append(" WHERE t.id = ? ")
-				.append(" AND ((ts.member_id IN " + Sql.listPrepared(groupsAndUserIds.toArray()) + " AND ts.action = ?)")
-				.append(" OR t.owner = ? )");
+				.append(" AND (")
+				.append("   (ts.member_id IN "+ Sql.listPrepared(groupsAndUserIds) +" AND ts.action = ?)")
+				.append("   OR t.owner = ?");
+			if(!admlStructuresIds.isEmpty()) {
+				query.append("   OR t.structure_id IN "+ Sql.listPrepared(admlStructuresIds));
+			}
+			query.append(" )");
 			values.add(Sql.parseId(id));
 			for(String value : groupsAndUserIds){
 				values.add(value);
 			}
 			values.add(sharedMethod);
 			values.add(user.getUserId());
+			for(String value : admlStructuresIds){
+				values.add(value);
+			}
 
 			// Execute
 			Sql.getInstance().prepared(query.toString(), values, new Handler<Message<JsonObject>>() {

--- a/src/main/java/net/atos/entng/actualites/services/impl/ActualitesRepositoryEvents.java
+++ b/src/main/java/net/atos/entng/actualites/services/impl/ActualitesRepositoryEvents.java
@@ -239,22 +239,9 @@ public class ActualitesRepositoryEvents extends SqlRepositoryEvents {
 			statementsBuilder.prepared("DELETE FROM actualites.info_shares WHERE member_id IN " + Sql.listPrepared(uIds.getList()), uIds);
 			// Delete users (Set deleted = true in users table)
 			statementsBuilder.prepared("UPDATE actualites.users SET deleted = true WHERE id IN " + Sql.listPrepared(uIds.getList()), uIds);
-			// WB-1402 Threads are now attached to a structure, with AMDLs having management rights. Do not delete them anymore.
-			// // Delete all threads where the owner is deleted and no manager rights shared on these resources
-			// // Cascade delete : the news that belong to these threads will be deleted too
-			// // thus, no need to delete news that do not have a manager because the thread owner is still there
-			// statementsBuilder.prepared("DELETE FROM actualites.thread" +
-			// 						  " USING (" +
-			// 							  " SELECT DISTINCT t.id, count(ts.member_id) AS managers" +
-			// 							  " FROM actualites.thread AS t" +
-			// 							  " LEFT OUTER JOIN actualites.thread_shares AS ts ON t.id = ts.resource_id AND ts.action = ?" +
-			// 							  " LEFT OUTER JOIN actualites.users AS u ON t.owner = u.id" +
-			// 							  " WHERE u.deleted = true" +
-			// 							  " GROUP BY t.id" +
-			// 						 " ) a" +
-			// 						 " WHERE actualites.thread.id = a.id" +
-			// 						 " AND a.managers = 0"
-			// 					  	  , new fr.wseduc.webutils.collections.JsonArray().add(MANAGE_RIGHT_ACTION));
+			// WB-1402 Do not delete anymore the threads whose owner is deleted and no manager rights are shared on.
+			// Because threads are now attached to a structure, with AMDLs having management rights.
+
 			Sql.getInstance().transaction(statementsBuilder.build(), SqlResult.validRowsResultHandler(new Handler<Either<String, JsonObject>>() {
 				@Override
 				public void handle(Either<String, JsonObject> event) {

--- a/src/main/java/net/atos/entng/actualites/services/impl/ActualitesRepositoryEvents.java
+++ b/src/main/java/net/atos/entng/actualites/services/impl/ActualitesRepositoryEvents.java
@@ -104,7 +104,7 @@ public class ActualitesRepositoryEvents extends SqlRepositoryEvents {
 
 
 			String queryThread =
-					"SELECT DISTINCT th.* " +
+					"SELECT DISTINCT th.id, th.title, th.icon, th.mode, th.owner, th.created, th.modified " +
 							"FROM " + threadTable + " th " +
 							"LEFT JOIN "+ threadSharesTable + " thS ON th.id = thS.resource_id " +
 							(exportSharedResources == true ? "" : "AND 0 = 1 ") +

--- a/src/main/java/net/atos/entng/actualites/services/impl/ActualitesRepositoryEvents.java
+++ b/src/main/java/net/atos/entng/actualites/services/impl/ActualitesRepositoryEvents.java
@@ -239,21 +239,22 @@ public class ActualitesRepositoryEvents extends SqlRepositoryEvents {
 			statementsBuilder.prepared("DELETE FROM actualites.info_shares WHERE member_id IN " + Sql.listPrepared(uIds.getList()), uIds);
 			// Delete users (Set deleted = true in users table)
 			statementsBuilder.prepared("UPDATE actualites.users SET deleted = true WHERE id IN " + Sql.listPrepared(uIds.getList()), uIds);
-			// Delete all threads where the owner is deleted and no manager rights shared on these resources
-			// Cascade delete : the news that belong to these threads will be deleted too
-			// thus, no need to delete news that do not have a manager because the thread owner is still there
-			statementsBuilder.prepared("DELETE FROM actualites.thread" +
-									  " USING (" +
-										  " SELECT DISTINCT t.id, count(ts.member_id) AS managers" +
-										  " FROM actualites.thread AS t" +
-										  " LEFT OUTER JOIN actualites.thread_shares AS ts ON t.id = ts.resource_id AND ts.action = ?" +
-										  " LEFT OUTER JOIN actualites.users AS u ON t.owner = u.id" +
-										  " WHERE u.deleted = true" +
-										  " GROUP BY t.id" +
-									 " ) a" +
-									 " WHERE actualites.thread.id = a.id" +
-									 " AND a.managers = 0"
-								  	  , new fr.wseduc.webutils.collections.JsonArray().add(MANAGE_RIGHT_ACTION));
+			// WB-1402 Threads are now attached to a structure, with AMDLs having management rights. Do not delete them anymore.
+			// // Delete all threads where the owner is deleted and no manager rights shared on these resources
+			// // Cascade delete : the news that belong to these threads will be deleted too
+			// // thus, no need to delete news that do not have a manager because the thread owner is still there
+			// statementsBuilder.prepared("DELETE FROM actualites.thread" +
+			// 						  " USING (" +
+			// 							  " SELECT DISTINCT t.id, count(ts.member_id) AS managers" +
+			// 							  " FROM actualites.thread AS t" +
+			// 							  " LEFT OUTER JOIN actualites.thread_shares AS ts ON t.id = ts.resource_id AND ts.action = ?" +
+			// 							  " LEFT OUTER JOIN actualites.users AS u ON t.owner = u.id" +
+			// 							  " WHERE u.deleted = true" +
+			// 							  " GROUP BY t.id" +
+			// 						 " ) a" +
+			// 						 " WHERE actualites.thread.id = a.id" +
+			// 						 " AND a.managers = 0"
+			// 					  	  , new fr.wseduc.webutils.collections.JsonArray().add(MANAGE_RIGHT_ACTION));
 			Sql.getInstance().transaction(statementsBuilder.build(), SqlResult.validRowsResultHandler(new Handler<Either<String, JsonObject>>() {
 				@Override
 				public void handle(Either<String, JsonObject> event) {

--- a/src/main/java/net/atos/entng/actualites/to/NewsThread.java
+++ b/src/main/java/net/atos/entng/actualites/to/NewsThread.java
@@ -19,16 +19,19 @@ public class NewsThread {
     // Caution: String is used to store ISO date because we won't manipulate data in most cases
     private final String modified;
 
+    private final String structure_id;
+
     private final ResourceOwner owner;
 
     private final Rights sharedRights;
 
-    public NewsThread(int id, String title, String icon, String created, String modified, ResourceOwner owner, Rights sharedRights) {
+    public NewsThread(int id, String title, String icon, String created, String modified, String structure_id, ResourceOwner owner, Rights sharedRights) {
         this.id = id;
         this.title = title;
         this.icon = icon;
         this.created = created;
         this.modified = modified;
+        this.structure_id = structure_id;
         this.owner = owner;
         this.sharedRights = sharedRights;
     }
@@ -55,6 +58,10 @@ public class NewsThread {
 
     public String getModified() {
         return modified;
+    }
+
+    public String getStructureId() {
+        return structure_id;
     }
 
     @JsonIgnore

--- a/src/main/resources/public/ts/behaviours.ts
+++ b/src/main/resources/public/ts/behaviours.ts
@@ -88,8 +88,18 @@ Behaviours.register('actualites', {
             if (!resource.myRights){
                 resource.myRights = {};
             }
+            const hasAdmlRightsFor = (behaviour, structureId) => {
+                // Adml have rights on these behaviours
+                return ['editThread', 'deleteThread', 'manager', 'share'].indexOf(behaviour)>=0 &&
+                       model.me.functions &&
+                       model.me.functions.ADMIN_LOCAL &&
+                       model.me.functions.ADMIN_LOCAL.scope &&
+                       model.me.functions.ADMIN_LOCAL.scope.indexOf(structureId)>=0;
+            }
             for (var behaviour in actualitesBehaviours.resources){
-                if (model.me.hasRight(resource, actualitesBehaviours.resources[behaviour]) || model.me.userId === resource.owner){
+                if (model.me.hasRight(resource, actualitesBehaviours.resources[behaviour]) 
+                    || model.me.userId === resource.owner
+                    || hasAdmlRightsFor(behaviour, resource.structure_id)){
                     if (resource.myRights[behaviour] !== undefined){
                         resource.myRights[behaviour] = resource.myRights[behaviour] && actualitesBehaviours.resources[behaviour];
                     } else {

--- a/src/main/resources/sql/019-attach-threads-to-structures.sql
+++ b/src/main/resources/sql/019-attach-threads-to-structures.sql
@@ -1,0 +1,14 @@
+-- WB-1402
+
+-- Allow NULL values for column thread.user_id and modify FK constraint => ON DELETE SET NULL
+-- *** Opération potentiellement longue ***
+ALTER TABLE actualites.thread 
+	DROP CONSTRAINT type_owner_fk,
+	ALTER COLUMN owner DROP NOT NULL,
+	ADD CONSTRAINT type_owner_fk FOREIGN KEY(owner) REFERENCES actualites.users(id) 
+		ON UPDATE CASCADE
+		ON DELETE SET NULL;
+
+-- Attach threads to a structure
+ALTER TABLE actualites.thread 
+	ADD COLUMN structure_id VARCHAR(36) NULL;

--- a/src/main/resources/sql/019-attach-threads-to-structures.sql
+++ b/src/main/resources/sql/019-attach-threads-to-structures.sql
@@ -1,6 +1,6 @@
 -- WB-1402
 
--- Allow NULL values for column thread.user_id and modify FK constraint => ON DELETE SET NULL
+-- Allow NULL values for column thread.owner and modify FK constraint => ON DELETE SET NULL
 -- *** Opération potentiellement longue ***
 ALTER TABLE actualites.thread 
 	DROP CONSTRAINT type_owner_fk,


### PR DESCRIPTION
## Describe your changes

Besoin initial : Lorsqu'un utilisateur ayant créé un fil est supprimé, le fil ne doit plus être supprimé avec lui. Cela évite de perdre des fils lorsque leur créateur change d'établissement. On souhaite aussi rattacher chaque fil à une structure, directement.

Le développement proposé implémente ce fonctionnement.
* Supprimer un utilisateur ne supprime plus les fils dont il est "owner",
* Ajout d'une colonne `structure_id` à la table `actualites.thread`,
* Ajout de la `structure_id` au retour de l'API de listing des fils,
* Modifiaction des behaviours pour élargir systématiquement le partage en gestion aux ADMLs de la structure,
* Les ADMLs de la structure, à laquelle un fil est rattaché, ont des autorisations identiques à celles d'un gestionnaire du fil.
(afin de s'assurer que chaque fil à toujours au moins un utilisateur “owner” ou un gestionnaire actif, on autorise désormais le groupe d'administrateurs locaux de sa structure de rattachement comme s'il était gestionnaire)

## Checklist tests

## Issue ticket number and link

[WB-1402](https://edifice-community.atlassian.net/browse/)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

[WB-1402]: https://edifice-community.atlassian.net/browse/WB-1402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ