### PR TITLE
feat: #WB-1404, auto-attach threads without a structure to a default one

### DIFF
--- a/src/main/java/net/atos/entng/actualites/Actualites.java
+++ b/src/main/java/net/atos/entng/actualites/Actualites.java
@@ -130,9 +130,9 @@ public class Actualites extends BaseServer {
 	}
 
 	@Override
-	protected Future<Void> postSqlMigration() {
+	protected Future<Void> postSqlScripts() {
 		final ThreadService threadService = new ThreadServiceSqlImpl().setEventBus(getEventBus(vertx));
-		return threadService.attachThreadsWithNullStructureToDefault();
+		return super.postSqlScripts().compose(Void -> threadService.attachThreadsWithNullStructureToDefault());
 	}
 
 }

--- a/src/main/java/net/atos/entng/actualites/Actualites.java
+++ b/src/main/java/net/atos/entng/actualites/Actualites.java
@@ -29,6 +29,8 @@ import net.atos.entng.actualites.services.ConfigService;
 import net.atos.entng.actualites.services.impl.ActualitesRepositoryEvents;
 
 import net.atos.entng.actualites.services.impl.ActualitesSearchingEvents;
+import net.atos.entng.actualites.services.impl.ThreadServiceSqlImpl;
+
 import org.entcore.common.http.BaseServer;
 import org.entcore.common.http.filter.ShareAndOwner;
 import org.entcore.common.service.impl.SqlCrudService;
@@ -36,11 +38,15 @@ import org.entcore.common.service.impl.SqlSearchService;
 import org.entcore.common.share.impl.SqlShareService;
 import org.entcore.common.sql.SqlConf;
 import org.entcore.common.sql.SqlConfs;
+
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.json.JsonArray;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import io.vertx.core.Future;
+import net.atos.entng.actualites.services.ThreadService;
 
 public class Actualites extends BaseServer {
 	public final static String NEWS_SCHEMA = "actualites";
@@ -121,6 +127,12 @@ public class Actualites extends BaseServer {
 		commentController.setCrudService(commentSqlCrudService);
 		addController(commentController);
 
+	}
+
+	@Override
+	protected Future<Void> postSqlMigration() {
+		final ThreadService threadService = new ThreadServiceSqlImpl();
+		return threadService.attachThreadsWithNullStructureToDefault();
 	}
 
 }

--- a/src/main/java/net/atos/entng/actualites/Actualites.java
+++ b/src/main/java/net/atos/entng/actualites/Actualites.java
@@ -96,7 +96,7 @@ public class Actualites extends BaseServer {
 		confThread.setSchema(getSchema());
 
 		// thread controller
-		ThreadController threadController = new ThreadController();
+		ThreadController threadController = new ThreadController(eb);
 		SqlCrudService threadSqlCrudService = new SqlCrudService(getSchema(), THREAD_TABLE, THREAD_SHARE_TABLE, new JsonArray().add("*"), new JsonArray().add("*"), true);
 		threadController.setCrudService(threadSqlCrudService);
 		threadController.setShareService(new SqlShareService(getSchema(),THREAD_SHARE_TABLE, eb, securedActions, null));
@@ -131,7 +131,7 @@ public class Actualites extends BaseServer {
 
 	@Override
 	protected Future<Void> postSqlMigration() {
-		final ThreadService threadService = new ThreadServiceSqlImpl();
+		final ThreadService threadService = new ThreadServiceSqlImpl().setEventBus(getEventBus(vertx));
 		return threadService.attachThreadsWithNullStructureToDefault();
 	}
 

--- a/src/main/java/net/atos/entng/actualites/controllers/ThreadController.java
+++ b/src/main/java/net/atos/entng/actualites/controllers/ThreadController.java
@@ -23,6 +23,7 @@ import static org.entcore.common.http.response.DefaultResponseHandler.arrayRespo
 import static org.entcore.common.http.response.DefaultResponseHandler.defaultResponseHandler;
 import static org.entcore.common.http.response.DefaultResponseHandler.notEmptyResponseHandler;
 import static org.entcore.common.user.UserUtils.getUserInfos;
+
 import net.atos.entng.actualites.Actualites;
 import net.atos.entng.actualites.filters.ThreadFilter;
 import net.atos.entng.actualites.services.ThreadService;
@@ -35,6 +36,7 @@ import org.entcore.common.events.EventStoreFactory;
 import org.entcore.common.http.filter.ResourceFilter;
 import org.entcore.common.user.UserInfos;
 import org.entcore.common.user.UserUtils;
+
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.JsonArray;
@@ -50,6 +52,7 @@ import fr.wseduc.security.SecuredAction;
 import fr.wseduc.webutils.Either;
 import fr.wseduc.webutils.I18n;
 import fr.wseduc.webutils.request.RequestUtils;
+import io.vertx.core.eventbus.EventBus;
 
 public class ThreadController extends ControllerHelper {
 
@@ -62,8 +65,8 @@ public class ThreadController extends ControllerHelper {
 	protected final ThreadService threadService;
 	protected final EventHelper eventHelper;
 
-	public ThreadController(){
-		this.threadService = new ThreadServiceSqlImpl();
+	public ThreadController(EventBus eb){
+		this.threadService = new ThreadServiceSqlImpl().setEventBus(eb);
 		final EventStore eventStore = EventStoreFactory.getFactory().getEventStore(Actualites.class.getSimpleName());
 		eventHelper = new EventHelper(eventStore);
 	}

--- a/src/main/java/net/atos/entng/actualites/services/ThreadService.java
+++ b/src/main/java/net/atos/entng/actualites/services/ThreadService.java
@@ -19,18 +19,18 @@
 
 package net.atos.entng.actualites.services;
 
+import java.util.List;
+import java.util.Map;
+
 import org.entcore.common.user.UserInfos;
 
+import fr.wseduc.webutils.Either;
+import fr.wseduc.webutils.security.SecuredAction;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import fr.wseduc.webutils.Either;
-import fr.wseduc.webutils.security.SecuredAction;
 import net.atos.entng.actualites.to.NewsThread;
-
-import java.util.List;
-import java.util.Map;
 
 public interface ThreadService {
 
@@ -43,5 +43,8 @@ public interface ThreadService {
 	public void getPublishSharedWithIds(String threadId, Handler<Either<String, JsonArray>> handler);
 
 	Future<List<NewsThread>> list(Map<String, SecuredAction> securedActions, UserInfos user);
+
+	/** Utility method to attach threads without a structure to their owner's structure, when a single one exists. */
+	Future<Void> attachThreadsWithNullStructureToDefault();
 
 }

--- a/src/main/java/net/atos/entng/actualites/services/impl/ThreadServiceSqlImpl.java
+++ b/src/main/java/net/atos/entng/actualites/services/impl/ThreadServiceSqlImpl.java
@@ -383,17 +383,21 @@ public class ThreadServiceSqlImpl implements ThreadService {
      */
     private Future<JsonArray> getUsersStructures(final List<String> ids) {
 		Promise<JsonArray> promise = Promise.promise();
-		JsonObject action = new JsonObject()
-			.put("action", "getUsersStructures")
-			.put("userIds", new JsonArray(ids));
-		eb.request("directory", action, handlerToAsyncHandler(event -> {
-			JsonArray res = event.body().getJsonArray("result", new JsonArray());
-			if ("ok".equals(event.body().getString("status")) && res != null) {
-				promise.complete(res);
-			} else {
-				promise.fail(event.body().getString("message"));
-			}
-		}));
+		if(ids==null || ids.isEmpty()) {
+			promise.complete(new JsonArray());
+		} else {
+			JsonObject action = new JsonObject()
+				.put("action", "getUsersStructures")
+				.put("userIds", new JsonArray(ids));
+			eb.request("directory", action, handlerToAsyncHandler(event -> {
+				JsonArray res = event.body().getJsonArray("result", new JsonArray());
+				if ("ok".equals(event.body().getString("status")) && res != null) {
+					promise.complete(res);
+				} else {
+					promise.fail(event.body().getString("message"));
+				}
+			}));
+		}
 		return promise.future();
     }
 

--- a/src/main/resources/jsonschema/admcTask.json
+++ b/src/main/resources/jsonschema/admcTask.json
@@ -1,0 +1,13 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"type": "object",
+	"additionalProperties" : false,
+	"properties": {
+		"task": {
+			"type": "string"
+		}
+	},
+	"required": [
+		"task"
+	]
+}


### PR DESCRIPTION
## Describe your changes

Requires : [PR 622 of edifice.io/entcore](https://github.com/edificeio/entcore/pull/622)

This PR adds a step after playing the SQL scripts : 
=> affect a default structure to threads, applying the following business rules : 

* only to threads where no structure is already attached,
* only if the owner is known and is attached to a single structure himself.

## Checklist tests

## Issue ticket number and link

[WB-14040](https://edifice-community.atlassian.net/browse/WB-1404)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)