### PR TITLE
fix:#COCO-5583 set publicationdate of published info to today

### DIFF
--- a/frontend/src/features/info-form/components/InfoDetailsForm.tsx
+++ b/frontend/src/features/info-form/components/InfoDetailsForm.tsx
@@ -22,6 +22,7 @@ export const INFO_DETAILS_DEFAULT_VALUES: InfoDetailsFormParams = {
 
 export const INFO_HOURS_DATE_DEFAULT = 7;
 
+//TODO replace constant by a function to avoid a long-lived tab may set date to an old timestamp instead of “today”
 export const INFO_DATES_RESET_VALUES: {
   publicationDate: Date;
   expirationDate: Date;

--- a/frontend/src/hooks/useInfoPublishOrSubmit.ts
+++ b/frontend/src/hooks/useInfoPublishOrSubmit.ts
@@ -3,7 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { INFO_DATES_RESET_VALUES } from '~/features';
 import { useI18n } from '~/hooks/useI18n';
-import { InfoDetails, InfoStatus } from '~/models/info';
+import { InfoDetails, InfoStatus, UpdateInfoPayload } from '~/models/info';
 import { invalidateThreadQueries, useUpdateInfo } from '~/services/queries';
 import { useUpdateStatsQueryCache } from '~/services/queries/hooks/useUpdateStatsQueryCache';
 
@@ -21,18 +21,19 @@ export function useInfoPublishOrSubmit() {
     if (!info.id) {
       throw new Error('infoId is undefined');
     }
+    let payload: UpdateInfoPayload = {};
 
     if (!info.publicationDate) {
-      info.publicationDate =
+      payload.publication_date =
         INFO_DATES_RESET_VALUES.publicationDate.toISOString();
-      info.expirationDate =
+      payload.expiration_date =
         INFO_DATES_RESET_VALUES.expirationDate.toISOString();
     }
     updateInfoMutate(
       {
         infoId: info.id,
         infoStatus: status,
-        payload: {},
+        payload: payload,
       },
       {
         onSuccess: () => {

--- a/frontend/src/models/info.ts
+++ b/frontend/src/models/info.ts
@@ -99,6 +99,23 @@ export interface OriginalInfo {
   shared: [];
 }
 
+export interface CreateInfoPayload {
+  title: string;
+  content: string;
+  thread_id: ThreadId;
+  publication_date?: string;
+  expiration_date?: string;
+  is_headline?: boolean;
+}
+
+export interface UpdateInfoPayload {
+  thread_id?: ThreadId;
+  title?: string;
+  content?: string;
+  is_headline?: boolean;
+  publication_date?: string;
+  expiration_date?: string;
+}
 export interface ThreadInfoStats {
   id: ThreadId | undefined;
   status: {

--- a/frontend/src/routes/redirections.tsx
+++ b/frontend/src/routes/redirections.tsx
@@ -14,7 +14,7 @@ export const manageRedirections = (): string | null => {
     const isDefault = matchPath('/default', hashLocation);
     if (isDefault) {
       // Suppress unused hash but do not reload the page.
-      return `/threads`;
+      return `/`;
     }
 
     // Link to a comment ?

--- a/frontend/src/services/api/infoService.ts
+++ b/frontend/src/services/api/infoService.ts
@@ -98,7 +98,7 @@ export const createInfoService = () => {
     },
 
     /**
-     * Update an Info (its status cannot change).
+     * Update an Info.
      * @param threadId
      * @param infoId
      * @param infoStatus

--- a/frontend/src/services/api/infoService.ts
+++ b/frontend/src/services/api/infoService.ts
@@ -2,6 +2,7 @@ import { odeServices, ShareRight } from '@edifice.io/client';
 import { checkHttpError } from '~/utils/checkHttpError';
 import { baseUrl, baseUrlAPI } from '.';
 import {
+  CreateInfoPayload,
   Info,
   InfoDetails,
   InfoExtendedStatus,
@@ -10,6 +11,7 @@ import {
   InfosStats,
   InfoStatus,
   OriginalInfo,
+  UpdateInfoPayload,
 } from '../../models/info';
 import { Share } from '../../models/share';
 import { ThreadId } from '../../models/thread';
@@ -85,14 +87,7 @@ export const createInfoService = () => {
      * @param payload
      * @returns ID of the newly created Info
      */
-    createDraft(payload: {
-      title: string;
-      content: string;
-      thread_id: ThreadId;
-      publication_date?: string;
-      expiration_date?: string;
-      is_headline?: boolean;
-    }) {
+    createDraft(payload: CreateInfoPayload) {
       return odeServices.http().post<{
         id: InfoId;
       }>(`${baseUrlAPI}/infos`, {
@@ -110,18 +105,7 @@ export const createInfoService = () => {
      * @param payload
      * @returns ID of the updated Info
      */
-    update(
-      infoId: InfoId,
-      infoStatus: InfoStatus,
-      payload: {
-        thread_id?: ThreadId; // FIXME Is uncommenting this line useful, or dangerous ?
-        title?: string;
-        content?: string;
-        is_headline?: boolean;
-        publication_date?: string;
-        expiration_date?: string;
-      },
-    ) {
+    update(infoId: InfoId, infoStatus: InfoStatus, payload: UpdateInfoPayload) {
       const status =
         infoStatus === InfoStatus.DRAFT
           ? 1

--- a/frontend/src/services/queries/info.ts
+++ b/frontend/src/services/queries/info.ts
@@ -8,7 +8,14 @@ import {
   useQuery,
   useQueryClient,
 } from '@tanstack/react-query';
-import { Info, InfoExtendedStatus, InfoId, InfoStatus } from '~/models/info';
+import {
+  CreateInfoPayload,
+  Info,
+  InfoExtendedStatus,
+  InfoId,
+  InfoStatus,
+  UpdateInfoPayload,
+} from '~/models/info';
 import { ThreadId } from '~/models/thread';
 import { useInfoAudienceStore } from '~/store/audienceStore';
 import { infoService } from '../api';
@@ -167,14 +174,8 @@ export const useCreateDraftInfo = () => {
   const { updateStatsQueryCache } = useUpdateStatsQueryCache();
 
   return useMutation({
-    mutationFn: (payload: {
-      title: string;
-      content: string;
-      thread_id: number;
-      publication_date?: string;
-      expiration_date?: string;
-      is_headline?: boolean;
-    }) => infoService.createDraft(payload),
+    mutationFn: (payload: CreateInfoPayload) =>
+      infoService.createDraft(payload),
     onMutate: async (payload) => {
       updateStatsQueryCache(payload.thread_id, InfoStatus.DRAFT, 1);
     },
@@ -191,15 +192,10 @@ export const useUpdateInfo = () => {
     }: {
       infoId: InfoId;
       infoStatus: InfoStatus;
-      payload: {
-        thread_id?: ThreadId;
-        title?: string;
-        content?: string;
-        is_headline?: boolean;
-        publication_date?: string;
-        expiration_date?: string;
-      };
-    }) => infoService.update(infoId, infoStatus, payload),
+      payload: UpdateInfoPayload;
+    }) => {
+      return infoService.update(infoId, infoStatus, payload);
+    },
     onSuccess: (params) => {
       queryClient.invalidateQueries({
         queryKey: infoQueryKeys.info({ infoId: params.id }),


### PR DESCRIPTION
- Introduce CreateInfoPayload / UpdateInfoPayload model types and reuse them across queries and API service methods.
- Update publish/submit flow to send publication_date and expiration_date in the update payload when missing.
- Replace inline payload type definitions in React Query mutations with shared model types.

Ticket : https://edifice-community.atlassian.net/browse/COCO-5583