### PR TITLE
fix: #IMPULS-6013, cron tigger

### DIFF
--- a/backend/src/main/java/net/atos/entng/actualites/cron/PublicationCron.java
+++ b/backend/src/main/java/net/atos/entng/actualites/cron/PublicationCron.java
@@ -36,7 +36,7 @@ public class PublicationCron implements Handler<Long> {
                       " JOIN actualites.users u_owner ON u_owner.id = i.owner " +
                       " JOIN actualites.users u_publisher ON u_publisher.id = i.publisher_id " +
                       " WHERE i.published = false AND i.status = 3 AND " +
-                      " (i.publication_date IS NOT NULL AND i.publication_date <  now()) ", new JsonArray(), validResultHandler( this::publishNews));
+                      " (i.publication_date IS NOT NULL AND i.publication_date < NOW() AT TIME ZONE 'UTC') ", new JsonArray(), validResultHandler( this::publishNews));
     }
 
     private void publishNews(Either<String, JsonArray> result) {


### PR DESCRIPTION
## Describe your changes

### Bug
Le cron de publication compare publication_date (stockée en UTC, sans fuseau) à now() (avec fuseau). PostgreSQL réinterprète alors la date dans le fuseau du serveur (Europe/Madrid), ce qui publie les actualités programmées avec un décalage (2h l'été, 1h l'hiver) : trop tôt. La notification timeline hérite de cette mauvaise heure et peut sortir de la fenêtre du mail quotidien.

### Résolution
Comparer avec NOW() AT TIME ZONE 'UTC' (comme partout ailleurs dans le module) au lieu de now().

## Checklist tests

## Issue ticket number and link

[#IMPULS-6013](https://edifice-community.atlassian.net/browse/IMPULS-6013)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)